### PR TITLE
fix: file moving logic and filter out specific files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,8 +65,8 @@ while :; do
   # shellcheck disable=SC2086
   yt-dlp -i --live-from-start --hls-use-mpegts --hls-prefer-native ${TITLE_FILTER_ARG} --download-archive "${RECORDED_FILE}" -f bestvideo+bestaudio --add-metadata --merge-output-format mp4 -o "${OUTPUT_DIR}" "${URL}"
 
-  # Move the file to the parent directory
+  # Move the file to the parent directory (but f140, f248, f299 files are not move)
   # shellcheck disable=SC2046
-  mv -v $(dirname "${OUTPUT_DIR}")/*.mp4 "${MOVE_DIR}"
+  find $(dirname "${OUTPUT_DIR}") -name "*.mp4" -not -name "*.f*.mp4" -exec mv {} "${MOVE_DIR}" \;
   sleep 5
 done

--- a/watch-new-movie/src/main.ts
+++ b/watch-new-movie/src/main.ts
@@ -60,6 +60,7 @@ function getMovies(): Movie[] {
       .filter((file) => fs.statSync(`${parent}${dir}/${file}`).isFile())
       .filter((file) => !file.includes('.f140'))
       .filter((file) => !file.includes('.f248'))
+      .filter((file) => !file.includes('.f299'))
       .filter((file) => file.endsWith('.mp4'))
     for (const file of files) {
       movies.push({


### PR DESCRIPTION
This pull request fixes the file moving logic in the entrypoint.sh script and adds additional filters to exclude specific files (f140, f248, f299) in the main.ts file.