### PR TITLE
docs: エージェント向けプロンプトファイルを追加

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # GitHub Copilot Instructions
 
 ## プロジェクト概要
-- 目的: Record and download YouTube live videos. Works with Docker (Docker Compose).
+Record and download YouTube live videos with support for channels and playlists. Docker/Docker Compose compatible for containerized deployment.
 
 ## 共通ルール
 - 会話は日本語で行う。
@@ -11,7 +11,8 @@
 - 既存のプロジェクトルールがある場合はそれを優先する。
 
 ## 技術スタック
-- パッケージマネージャー: pnpm 優先（ロックファイルに従う）。
+- 言語: TypeScript, Shell
+- パッケージマネージャー: yarn
 
 ## コーディング規約
 - フォーマット: 既存設定（ESLint / Prettier / formatter）に従う。
@@ -22,9 +23,29 @@
 - TypeScript 使用時は strict 前提とし、`skipLibCheck` で回避しない。
 - 関数やインターフェースには docstring（JSDoc など）を記載する。
 
-## 開発コマンド
+### 開発コマンド
 ```bash
-# README を確認してください
+# install
+yarn install
+
+# dev
+ts-node-dev -r tsconfig-paths/register ./src/main.ts
+
+# build
+ts-node -r tsconfig-paths/register ./src/main.ts
+
+# compile
+tsc -p .
+
+# test
+tsc -p . --noEmit
+
+# lint
+run-p -c lint:prettier lint:eslint lint:tsc
+
+# fix
+run-s fix:prettier fix:eslint
+
 ```
 
 ## テスト方針
@@ -35,5 +56,15 @@
 - ログに機密情報を出力しない。
 
 ## ドキュメント更新
+- 実装確定後、同一コミットまたは追加コミットで更新する。
+- README、API ドキュメント、コメント等は常に最新状態を保つ。
 
 ## リポジトリ固有
+- **config_files**: {'recorder.env': 'Runtime configuration (CHANNEL, PLAYLIST, TARGET, TITLE_FILTER)', 'docker-compose.yml': 'Docker Compose setup for containerized execution'}
+**workflow_ci:**
+  - nodejs-ci.yml
+  - shell-ci.yml
+  - hadolint-ci.yml
+  - docker.yml
+  - add-reviewer.yml
+- **note**: Docker-first architecture for production deployment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,11 @@
 - ログに機密情報を出力しない。
 
 ## リポジトリ固有
+- **config_files**: {'recorder.env': 'Runtime configuration (CHANNEL, PLAYLIST, TARGET, TITLE_FILTER)', 'docker-compose.yml': 'Docker Compose setup for containerized execution'}
+**workflow_ci:**
+  - nodejs-ci.yml
+  - shell-ci.yml
+  - hadolint-ci.yml
+  - docker.yml
+  - add-reviewer.yml
+- **note**: Docker-first architecture for production deployment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,14 @@
 - 前提・仮定・不確実性を明示し、仮定を事実のように扱わない。
 
 ## プロジェクト概要
-- 目的: Record and download YouTube live videos. Works with Docker (Docker Compose).
+Record and download YouTube live videos with support for channels and playlists. Docker/Docker Compose compatible for containerized deployment.
+
+### 技術スタック
+- **言語**: TypeScript, Shell
+- **フレームワーク**: Node.js, ts-node
+- **パッケージマネージャー**: yarn
+- **主要な依存関係**:
+  - axios@1.13.2
 
 ## 重要ルール
 - 会話言語: 日本語
@@ -42,25 +49,70 @@
 - TypeScript 使用時は `skipLibCheck` で回避しない。
 - 関数やインターフェースには docstring（JSDoc など）を記載する。
 
+### コーディング規約
+- **eslint**: Uses @book000/eslint-config v1.12.40, extends standard config
+- **prettier**: Enabled with .prettierrc.yml configuration
+**typescript:**
+  - target: esnext
+  - moduleResolution: Node
+  - strict: True
+  - lib: ['ESNext', 'ESNext.AsyncIterable', 'DOM']
+- **path_aliases**: @/* → ./src/*
+
 ## 相談ルール
 - Codex CLI: 実装レビュー、局所設計、整合性確認に使う。
 - Gemini CLI: 外部仕様や最新情報の確認に使う。
 - 他エージェントの指摘は黙殺せず、採用または理由を明記して不採用とする。
 
-## 開発コマンド
+### 開発コマンド
 ```bash
-# README を確認してください
+# install
+yarn install
+
+# dev
+ts-node-dev -r tsconfig-paths/register ./src/main.ts
+
+# build
+ts-node -r tsconfig-paths/register ./src/main.ts
+
+# compile
+tsc -p .
+
+# test
+tsc -p . --noEmit
+
+# lint
+run-p -c lint:prettier lint:eslint lint:tsc
+
+# fix
+run-s fix:prettier fix:eslint
+
 ```
 
-## アーキテクチャと主要ファイル
+### プロジェクト構造
+
+**主要ディレクトリ:**
+- `watch-new-movie (TypeScript source)`
+- `.github/workflows (CI/CD)`
+- `docker-compose.yml (container orchestration)`
+
+**重要ファイル:**
+- `watch-new-movie/package.json`
+- `watch-new-movie/tsconfig.json`
+- `watch-new-movie/eslint.config.mjs`
+- `docker-compose.yml`
+- `Dockerfile`
 
 ## 実装パターン
+- 既存のコードパターンに従う。
+- プロジェクト固有の実装ガイドラインがある場合はそれに従う。
 
 ## テスト
 - 方針: 変更内容に応じてテストを追加する。
 
 ## ドキュメント更新ルール
 - 更新タイミング: 実装確定後、同一コミットまたは追加コミットで更新する。
+- README、API ドキュメント、コメント等は常に最新状態を保つ。
 
 ## 作業チェックリスト
 
@@ -91,3 +143,11 @@
 6. PR 本文の崩れがないことを確認する。
 
 ## リポジトリ固有
+- **config_files**: {'recorder.env': 'Runtime configuration (CHANNEL, PLAYLIST, TARGET, TITLE_FILTER)', 'docker-compose.yml': 'Docker Compose setup for containerized execution'}
+**workflow_ci:**
+  - nodejs-ci.yml
+  - shell-ci.yml
+  - hadolint-ci.yml
+  - docker.yml
+  - add-reviewer.yml
+- **note**: Docker-first architecture for production deployment

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,7 +15,14 @@
 - 日本語と英数字の間には半角スペースを入れる。
 
 ## プロジェクト概要
-- 目的: Record and download YouTube live videos. Works with Docker (Docker Compose).
+Record and download YouTube live videos with support for channels and playlists. Docker/Docker Compose compatible for containerized deployment.
+
+### 技術スタック
+- **言語**: TypeScript, Shell
+- **フレームワーク**: Node.js, ts-node
+- **パッケージマネージャー**: yarn
+- **主要な依存関係**:
+  - axios@1.13.2
 
 ## コーディング規約
 - フォーマット: 既存設定（ESLint / Prettier / formatter）に従う。
@@ -23,9 +30,29 @@
 - コメント言語: 日本語
 - エラーメッセージ: 英語
 
-## 開発コマンド
+### 開発コマンド
 ```bash
-# README を確認してください
+# install
+yarn install
+
+# dev
+ts-node-dev -r tsconfig-paths/register ./src/main.ts
+
+# build
+ts-node -r tsconfig-paths/register ./src/main.ts
+
+# compile
+tsc -p .
+
+# test
+tsc -p . --noEmit
+
+# lint
+run-p -c lint:prettier lint:eslint lint:tsc
+
+# fix
+run-s fix:prettier fix:eslint
+
 ```
 
 ## 注意事項
@@ -34,3 +61,11 @@
 - 既存のプロジェクトルールがある場合はそれを優先する。
 
 ## リポジトリ固有
+- **config_files**: {'recorder.env': 'Runtime configuration (CHANNEL, PLAYLIST, TARGET, TITLE_FILTER)', 'docker-compose.yml': 'Docker Compose setup for containerized execution'}
+**workflow_ci:**
+  - nodejs-ci.yml
+  - shell-ci.yml
+  - hadolint-ci.yml
+  - docker.yml
+  - add-reviewer.yml
+- **note**: Docker-first architecture for production deployment


### PR DESCRIPTION
## Summary
- GitHub Copilot、Claude Code、Gemini CLI などの AI エージェント向けプロンプトファイルを追加しました
- `.github/copilot-instructions.md`: GitHub Copilot 向けの指示
- `CLAUDE.md`: Claude Code 向けの指示
- `AGENTS.md`: 一般的な AI エージェント向けの指示
- `GEMINI.md`: Gemini CLI 向けの指示

## Details
各ファイルには以下の情報が含まれています：
- プロジェクト概要
- 技術スタック（実際のコード分析に基づく）
- 開発コマンド
- アーキテクチャ
- コーディング規約

🤖 Generated with [Claude Code](https://claude.com/claude-code)