### PR TITLE
fix: TypeScript v6.0 互換性のため tsconfig.json を修正

### DIFF
--- a/watch-new-movie/tsconfig.json
+++ b/watch-new-movie/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ESNext", "ESNext.AsyncIterable", "DOM"],
     "outDir": "./dist",
+    "rootDir": "./src",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,
@@ -20,8 +21,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
     "newLine": "LF",
+    "types": ["node"],
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## 概要

TypeScript v6.0 との互換性を確保するため、`watch-new-movie/tsconfig.json` を修正します。

Fixes #1315

## 変更内容

- `moduleResolution`: `"Node"` → `"bundler"`（TypeScript 7.0 で削除予定の非推奨設定を更新）
- `rootDir`: `"./src"` を追加（TypeScript 6.0 でデフォルト推論の動作変更に対応）
- `baseUrl`: `"."` を削除（パスエイリアスが相対パスを使用しているため不要）
- `types`: `["node"]` を追加（TypeScript 6.0 で `@types/node` の自動読み込みが廃止）

## 確認事項

- [x] `tsc --noEmit` によるビルドが成功することを確認