### PR TITLE
fix(watch-new-movie): resolve unicorn lint rule violations

### DIFF
--- a/watch-new-movie/src/main.ts
+++ b/watch-new-movie/src/main.ts
@@ -13,17 +13,17 @@ function getMovies(): Movie[] {
   const dataDirectories = fs
     .readdirSync(parent)
     .filter((file) => fs.statSync(parent + file).isDirectory())
-  for (const dir of dataDirectories) {
+  for (const directory of dataDirectories) {
     const files = fs
-      .readdirSync(parent + dir)
-      .filter((file) => fs.statSync(`${parent}${dir}/${file}`).isFile())
+      .readdirSync(parent + directory)
+      .filter((file) => fs.statSync(`${parent}${directory}/${file}`).isFile())
       .filter((file) => !file.includes('.f140'))
       .filter((file) => !file.includes('.f248'))
       .filter((file) => !file.includes('.f299'))
       .filter((file) => file.endsWith('.mp4'))
     for (const file of files) {
       movies.push({
-        dirname: dir,
+        dirname: directory,
         filename: file,
       })
     }
@@ -36,7 +36,7 @@ async function main() {
   const notified: string[] = fs.existsSync('/data/notified.json')
     ? JSON.parse(fs.readFileSync('/data/notified.json').toString())
     : []
-  const init = notified.length === 0
+  const isInitialRun = notified.length === 0
   for (const movie of movies) {
     const key = movie.dirname + '/' + movie.filename
     if (notified.includes(key)) {
@@ -45,11 +45,11 @@ async function main() {
     console.log(movie)
     notified.push(key)
 
-    if (init) {
+    if (isInitialRun) {
       continue
     }
-    await axios
-      .post('http://discord-deliver', {
+    try {
+      await axios.post('http://discord-deliver', {
         embed: {
           title: `Downloaded movie - youtube-live-recorder`,
           color: 0x00_ff_00,
@@ -67,16 +67,20 @@ async function main() {
           ],
         },
       })
-      .catch(() => null)
+    } catch {
+      // Discord への通知失敗は握りつぶし、通知済み管理を継続する
+    }
   }
   fs.writeFileSync('/data/notified.json', JSON.stringify(notified))
 }
 
 ;(async () => {
-  await main().catch(async (error: unknown) => {
+  try {
+    await main()
+  } catch (error) {
     console.error(error)
-    await axios
-      .post('http://discord-deliver', {
+    try {
+      await axios.post('http://discord-deliver', {
         embed: {
           title: `Error`,
           description: (error as Error).message,
@@ -89,6 +93,8 @@ async function main() {
           ],
         },
       })
-      .catch(() => null)
-  })
+    } catch {
+      // Discord へのエラー通知自体が失敗しても、元のエラーはログ済みのため無視する
+    }
+  }
 })()


### PR DESCRIPTION
## Summary

An upcoming `@book000/eslint-config` bump (e.g. #1327, 1.15.4 -> 1.15.44) pulls in a newer `eslint-plugin-unicorn` (v71) that newly flags pre-existing code in `watch-new-movie/src/main.ts`:

- `unicorn/name-replacements`: loop variable `dir` -> `directory`
- `unicorn/consistent-boolean-name`: `init` -> `isInitialRun`
- `unicorn/prefer-await` (x3): `.catch()` promise chaining converted to `try`/`await`/`catch`

No behavior change. Verified locally by temporarily installing `@book000/eslint-config@1.15.44` and confirming `yarn lint` (prettier + eslint + tsc) passes clean, then reverting that dependency bump (left to the Renovate PR) and confirming `yarn lint` still passes at the original `1.15.4` too.

This unblocks the `@book000/eslint-config` Renovate PR.