### PR TITLE
fix(watch-new-movie): resolve eslint-config v1.16.1 unicorn lint errors

### DIFF
--- a/watch-new-movie/src/main.ts
+++ b/watch-new-movie/src/main.ts
@@ -36,7 +36,7 @@ async function main() {
   const notified: string[] = fs.existsSync('/data/notified.json')
     ? JSON.parse(fs.readFileSync('/data/notified.json').toString())
     : []
-  const init = notified.length === 0
+  const isInitialRun = notified.length === 0
   for (const movie of movies) {
     const key = movie.dirname + '/' + movie.filename
     if (notified.includes(key)) {
@@ -45,11 +45,11 @@ async function main() {
     console.log(movie)
     notified.push(key)
 
-    if (init) {
+    if (isInitialRun) {
       continue
     }
-    await axios
-      .post('http://discord-deliver', {
+    try {
+      await axios.post('http://discord-deliver', {
         embed: {
           title: `Downloaded movie - youtube-live-recorder`,
           color: 0x00_ff_00,
@@ -67,16 +67,20 @@ async function main() {
           ],
         },
       })
-      .catch(() => null)
+    } catch {
+      // 通知配信の失敗は無視する
+    }
   }
   fs.writeFileSync('/data/notified.json', JSON.stringify(notified))
 }
 
 ;(async () => {
-  await main().catch(async (error: unknown) => {
+  try {
+    await main()
+  } catch (error: unknown) {
     console.error(error)
-    await axios
-      .post('http://discord-deliver', {
+    try {
+      await axios.post('http://discord-deliver', {
         embed: {
           title: `Error`,
           description: (error as Error).message,
@@ -89,6 +93,8 @@ async function main() {
           ],
         },
       })
-      .catch(() => null)
-  })
+    } catch {
+      // 通知配信の失敗は無視する
+    }
+  }
 })()


### PR DESCRIPTION
## What
Fixes the `unicorn/consistent-boolean-name` and `unicorn/prefer-await` lint errors in `watch-new-movie/src/main.ts` surfaced by #1327's `@book000/eslint-config` v1.16.1 bump.

## Why
#1327 bumps `@book000/eslint-config` 1.15.4 -> 1.16.1, which brings in a newer `eslint-plugin-unicorn` ruleset. This flags 4 pre-existing style issues:
- `unicorn/consistent-boolean-name`: boolean variable `init` should start with `is`/`are`/etc.
- `unicorn/prefer-await` (x3): `.catch()` promise chaining instead of `try`/`await`/`catch`

No behavior change: renamed `init` -> `isInitialRun`, and converted the 3 `.catch()` chains to `try`/`await`/`catch` blocks that silently swallow Discord delivery failures, matching prior behavior.

## Verification
Verified locally with both `@book000/eslint-config@1.16.1` (target, applied temporarily from #1327's own `package.json`/`yarn.lock`) and `1.15.4` (current baseline): `yarn lint` (prettier+eslint+tsc) clean on both, no regression. The dependency bump itself is left to #1327 (not part of this PR).

Not affiliated with #1327 -- opened from a fork since I don't have push access to this repo.