### PR TITLE
chore: worktree 用に .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+recorder.env
+discord-deliver.env
+*.env


### PR DESCRIPTION
## 概要

`git worktree` で新しい作業ディレクトリを作成した際に、gitignore 対象だが動作に必須なローカル設定ファイルを引き継げるよう `.worktreeinclude` を追加しました。

## 追加したパターン

```
recorder.env
discord-deliver.env
*.env
```

## 根拠

- `.gitignore` で `*.env` が除外されている（ローカル設定・データを Git 管理外にする方針）。
- `docker-compose.yml` の `recorder` / `discord-deliver` サービスがそれぞれ `env_file: recorder.env` / `discord-deliver.env` を参照している。
- `README.md` に「Docker Compose 利用時の設定ファイルは `recorder.env`」と明記され、`TARGET` / `CHANNEL` / `PLAYLIST` / `TITLE_FILTER` などの変数が説明されている。
- `CLAUDE.md` にも `recorder.env`（録画対象設定、`TARGET` は必須で保存先ディレクトリ名になる）と `discord-deliver.env`（Discord 通知設定）の記載がある。
- リポジトリ内に `.env.example` 等のテンプレートファイルが存在しないため、新しい worktree では既存チェックアウトからコピーする以外に復元手段がない。

## レビュー結果

- Lite review: 指摘事項なし（対象がパターンリストのみの追加のため、CLAUDE.md 準拠・バグ・コメント品質・セキュリティいずれも問題なし）。

## 関連

- https://github.com/book000/book000/issues/132
