### PR TITLE
feat: 出力ファイル名パターンを環境変数で指定できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Either `CHANNEL` or `PLAYLIST` is required.
 - `CHANNEL` (optional): Specify the ID of the channel to be recorded.
 - `PLAYLIST` (optional): Specify the ID of the playlist to be recorded.
 - `TITLE_FILTER` (optional): When filtering with the title name, specify the textbook to filter.
+- `OUTPUT_FILENAME_PATTERN` (optional): Specify the yt-dlp output template for the recorded filename (e.g. `%(title)s-%(id)s.%(ext)s` to avoid overwriting recordings with the same title). Defaults to `%(title)s.%(ext)s`.
 
 ## Warning / Disclaimer
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,8 @@ fi
 
 # Put the part file generated during download in the part directory
 # Move only mp4 file after download completes
-OUTPUT_DIR="/data/${TARGET}/part/%(title)s.%(ext)s"
+OUTPUT_FILENAME_PATTERN="${OUTPUT_FILENAME_PATTERN:-%(title)s.%(ext)s}"
+OUTPUT_DIR="/data/${TARGET}/part/${OUTPUT_FILENAME_PATTERN}"
 if [[ ! -d $(dirname "${OUTPUT_DIR}") ]]; then
   mkdir -p "$(dirname "${OUTPUT_DIR}")"
 fi


### PR DESCRIPTION
## 概要

`entrypoint.sh` の録画ファイル名テンプレート (`OUTPUT_DIR` の `%(title)s.%(ext)s` 部分) が完全にハードコードされており、環境変数で変更できなかった。同一タイトルの録画を複数回行うと上書きされるリスクがあるため、ファイル名テンプレートを環境変数で指定できるようにする。

## 変更内容

- `OUTPUT_FILENAME_PATTERN` 環境変数を追加。未設定時は従来どおり `%(title)s.%(ext)s` を使用する(後方互換)。
- 例: `OUTPUT_FILENAME_PATTERN=%(title)s-%(id)s.%(ext)s` とすることで、動画 ID を含めて上書きを回避できる。
- README.md の Configuration セクションに新しい環境変数のドキュメントを追加。

Closes #1407

## 動作確認

- `shellcheck entrypoint.sh` がエラーなく通ることを確認。