### PR TITLE
feat: Deno を導入し、録画できない配信に対応する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,9 @@ docker compose down         # 停止
 ## リポジトリ固有
 
 - **Docker Hub**: `book000/youtube-live-recorder`（recorder）と `book000/youtube-live-recorder-watch-new-movie`（Node.js）の 2 イメージを公開。
-- **Node.js バージョン**: `watch-new-movie/.node-version` で固定（現在 24.18.0）。
-- **yt-dlp バージョン**: ルート `Dockerfile` の `ENV YT_DLP_VERSION` を Renovate が管理（現在 2026.07.04）。
+- **Node.js バージョン**: `watch-new-movie/.node-version` で固定。
+- **yt-dlp バージョン**: ルート `Dockerfile` の `ENV YT_DLP_VERSION` を Renovate が管理。
+- **Deno バージョン**: ルート `Dockerfile` の `ENV DENO_VERSION` を Renovate が管理。yt-dlp が JavaScript ランタイムとして使用する。
 - **GitHub Actions**:
   - `nodejs-ci.yml`: `book000/templates` の再利用可能ワークフローで `watch-new-movie` をビルド。
   - `docker.yml`: 両 Docker イメージのビルド/公開。

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3-slim
 # hadolint ignore=DL3008
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y curl ffmpeg jq && \
+    apt-get install --no-install-recommends -y curl ffmpeg jq unzip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -11,6 +11,19 @@ RUN apt-get update && \
 ENV YT_DLP_VERSION=2026.07.04
 RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/yt-dlp -o /usr/local/bin/yt-dlp && \
     chmod a+rx /usr/local/bin/yt-dlp
+
+# renovate: datasource=github-releases depName=denoland/deno versioning=loose
+ENV DENO_VERSION=v2.9.5
+ARG TARGETARCH
+RUN case "${TARGETARCH}" in \
+      amd64) DENO_ARCH=x86_64-unknown-linux-gnu ;; \
+      arm64) DENO_ARCH=aarch64-unknown-linux-gnu ;; \
+      *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    curl -L "https://github.com/denoland/deno/releases/download/${DENO_VERSION}/deno-${DENO_ARCH}.zip" -o /tmp/deno.zip && \
+    unzip /tmp/deno.zip -d /usr/local/bin && \
+    chmod a+rx /usr/local/bin/deno && \
+    rm /tmp/deno.zip
 
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,7 @@ MOVE_DIR="/data/${TARGET}/"
 
 if [[ ! -f ${RECORDED_FILE} ]]; then
   echo "No recorded file found, add all videos to the recorded file"
-  yt-dlp -q --flat-playlist --print-to-file id ids.txt "${URL}"
+  yt-dlp -q --flat-playlist --js-runtimes deno --print-to-file id ids.txt "${URL}"
   xargs -I {} echo youtube {} < ids.txt >> "${RECORDED_FILE}"
 fi
 
@@ -63,7 +63,7 @@ while :; do
   fi
 
   # shellcheck disable=SC2086
-  yt-dlp -i --live-from-start --hls-use-mpegts --hls-prefer-native ${TITLE_FILTER_ARG} --download-archive "${RECORDED_FILE}" -f bestvideo+bestaudio --add-metadata --merge-output-format mp4 -o "${OUTPUT_DIR}" "${URL}"
+  yt-dlp -i --live-from-start --hls-use-mpegts --hls-prefer-native --js-runtimes deno ${TITLE_FILTER_ARG} --download-archive "${RECORDED_FILE}" -f bestvideo+bestaudio --add-metadata --merge-output-format mp4 -o "${OUTPUT_DIR}" "${URL}"
 
   # Move the file to the parent directory (but f140, f248, f299 files are not move)
   # shellcheck disable=SC2046


### PR DESCRIPTION
## 概要

Deno がインストールされていないと、yt-dlp が以下の警告を出力する。

> WARNING: [youtube] No supported JavaScript runtime could be found. Only deno is enabled by default; to use another runtime add --js-runtimes RUNTIME[:PATH] to your command/config.

Deno が無い場合、yt-dlp は android_vr クライアントでしか接続できず、HLS のマニフェストファイルを取得できない配信が存在する。

## 変更内容

- `Dockerfile`: Deno を `TARGETARCH`(amd64/arm64)に応じたバイナリでインストール(yt-dlp と同様、Renovate 管理の pin コメント付き)。
- `entrypoint.sh`: 実際の抽出を行う yt-dlp 呼び出し(`--flat-playlist` 実行時とメインループ)に `--js-runtimes deno` を追加。
- `CLAUDE.md`: `DENO_VERSION` の記載を追加。あわせて陳腐化しやすい各バージョン行の「現在 x.x.x」表記を削除。

## 動作確認

- `hadolint Dockerfile`: エラーなし
- `shellcheck entrypoint.sh`: エラーなし
- `docker build` (amd64): 成功、`deno --version` / `yt-dlp --js-runtimes deno --version` とも正常動作
- arm64 向け `TARGETARCH` 分岐は QEMU 未設定の検証環境ではビルドできなかったが、シェルの `case` 分岐ロジック単体では想定通り `aarch64-unknown-linux-gnu` に解決することを確認済み。プロジェクトの CI (`docker.yml`) は amd64 のみのビルドのため、既存の CI には影響しない。

Closes #1409
