### PR TITLE
docs: make English the project's primary language

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,13 +10,14 @@ Guidelines for GitHub Copilot when reviewing pull requests in this repository. P
 
 ## Review Priorities
 
-- **Language conventions**: Review comments are in English. Code comments / JSDoc are in English, error messages are in English.
+- **Language conventions**: Review comments are in English. Code comments / JSDoc are in English, error messages are in English. Shell/script output (recorder logs, `entrypoint.sh` messages) is English, without emoji.
 - **Type safety**: TypeScript assumes strict mode. Flag added `any`, enabling `skipLibCheck`, or suppressed type errors. Confirm new functions/interfaces have English JSDoc.
 - **Error handling**: Notification failures are intentionally swallowed (see below), but check that exceptions in newly added logic (file scanning, JSON read/write, etc.) are not silently swallowed.
 - **Hardcoded configuration**: Confirm newly added configuration values go through environment variables. Check that tokens, webhook URLs, or credentials are not hardcoded in code or config files.
 - **Shell scripts**: For `entrypoint.sh` changes, check for unquoted variable expansions and whether input validation (e.g. for `TARGET`) is broken. Confirm ShellCheck compliance.
 - **Dockerfile**: Confirm hadolint compliance. Check whether base image or package changes are appropriate.
 - **Notification format**: Check that the Discord Embed colors (success `0x00ff00` / error `0xff0000`) and field structure are not broken.
+- **Idempotency invariants**: Do not approve changes that remove or weaken `watch-new-movie/src/main.ts`'s per-key (`dirname/filename`) notification tracking or its first-run (`notified.json` empty) silent-bootstrap behavior — both are intentional, not bugs.
 
 ## Known Non-Issues (do not flag)
 
@@ -28,7 +29,11 @@ Guidelines for GitHub Copilot when reviewing pull requests in this repository. P
 - **Dependency versions**: Versions in `package.json` and `Dockerfile` (including `YT_DLP_VERSION`) are managed by Renovate. No need to flag them as "outdated dependencies".
 - **`# shellcheck disable=...` comments in `entrypoint.sh`**: These are deliberate, already-considered suppressions.
 
+## General
+
+- Do not suggest adding tools, frameworks, dependencies, or CI steps that are not already in the repository.
+
 ## Convention Reference
 
-- Commits: [Conventional Commits](https://www.conventionalcommits.org/) (`<description>` in English). Branches: [Conventional Branch](https://conventional-branch.github.io) short form.
+- Commits: [Conventional Commits](https://www.conventionalcommits.org/) (`<description>` in English). Branches: [Conventional Branch](https://conventional-branch.github.io) short form. PR titles/bodies must be in English (enforced by `check-pr-language.yml`).
 - Lint/Format: Follows ESLint (`watch-new-movie/eslint.config.mjs`) and Prettier (`watch-new-movie/.prettierrc.yml`). CI runs the equivalent of `yarn lint` and `yarn compile:test`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,34 +1,34 @@
-# GitHub Copilot レビュー指示
+# GitHub Copilot Review Instructions
 
-GitHub Copilot がこのリポジトリの Pull Request をレビューする際の指針です。以下の観点を優先し、既知の非問題を誤検知として指摘しないでください。
+Guidelines for GitHub Copilot when reviewing pull requests in this repository. Prioritize the following perspectives and do not flag the known non-issues below as false positives.
 
-## プロジェクト前提
+## Project Assumptions
 
-- 2 サービス構成: `recorder`（Python/Bash・ルートの `entrypoint.sh`、`yt-dlp`/`ffmpeg` 使用）と `watch-new-movie`（Node.js/TypeScript）。
-- `watch-new-movie` は `/data/` 配下の MP4 を検知し `http://discord-deliver`（Docker Compose のサービス名）へ通知する。
-- Node.js アプリのソースは `watch-new-movie/src/main.ts` のみ。
+- Two-service composition: `recorder` (Python/Bash, root `entrypoint.sh`, uses `yt-dlp`/`ffmpeg`) and `watch-new-movie` (Node.js/TypeScript).
+- `watch-new-movie` detects MP4 files under `/data/` and notifies `http://discord-deliver` (a Docker Compose service name).
+- The only Node.js app source is `watch-new-movie/src/main.ts`.
 
-## レビューで重視する点
+## Review Priorities
 
-- **言語規約**: レビューコメントは日本語。コード内コメント・JSDoc は日本語、エラーメッセージは英語。日本語と英数字の間に半角スペースがあるか。
-- **型安全性**: TypeScript は strict 前提。`any` の追加、`skipLibCheck` の有効化、型エラーの握り潰しは指摘する。新規の関数・インターフェースに日本語 JSDoc があるか確認する。
-- **エラーハンドリング**: 通知失敗は握り潰す設計だが（下記参照）、ファイル走査・JSON 読み書きなど新規追加ロジックの例外が握り潰されていないか確認する。
-- **設定のハードコード**: 新たに追加される設定値は環境変数経由か。トークン・Webhook URL・認証情報がコードや設定ファイルに直書きされていないか。
-- **シェルスクリプト**: `entrypoint.sh` の変更では、変数の未クオート展開や `TARGET` 等の入力検証が崩れていないか。ShellCheck 準拠か。
-- **Dockerfile**: hadolint 準拠か。ベースイメージやパッケージ導入の変更が妥当か。
-- **通知フォーマット**: Discord Embed の色（成功 `0x00ff00` / エラー `0xff0000`）やフィールド構造を壊していないか。
+- **Language conventions**: Review comments are in English. Code comments / JSDoc are in English, error messages are in English.
+- **Type safety**: TypeScript assumes strict mode. Flag added `any`, enabling `skipLibCheck`, or suppressed type errors. Confirm new functions/interfaces have English JSDoc.
+- **Error handling**: Notification failures are intentionally swallowed (see below), but check that exceptions in newly added logic (file scanning, JSON read/write, etc.) are not silently swallowed.
+- **Hardcoded configuration**: Confirm newly added configuration values go through environment variables. Check that tokens, webhook URLs, or credentials are not hardcoded in code or config files.
+- **Shell scripts**: For `entrypoint.sh` changes, check for unquoted variable expansions and whether input validation (e.g. for `TARGET`) is broken. Confirm ShellCheck compliance.
+- **Dockerfile**: Confirm hadolint compliance. Check whether base image or package changes are appropriate.
+- **Notification format**: Check that the Discord Embed colors (success `0x00ff00` / error `0xff0000`) and field structure are not broken.
 
-## 指摘しない既知の非問題
+## Known Non-Issues (do not flag)
 
-- **テストの欠如**: テストフレームワークは未導入。ユニットテストの追加を一律に要求しない。
-- **通知呼び出しの `.catch(() => null)`**: `axios.post('http://discord-deliver', …).catch(() => null)` は通知失敗でアプリを止めない意図的な設計。
-- **`http://discord-deliver` のハードコード**: Docker Compose のサービス名であり、秘密情報でも設定漏れでもない。
-- **`/data/` の絶対パス**: コンテナ内の固定マウント先で意図的。
-- **中間フォーマットの除外**: `.f140` `.f248` `.f299` の除外や単純な `.includes` 判定は既知の仕様。
-- **依存バージョン**: `package.json` や `Dockerfile`（`YT_DLP_VERSION` 含む）のバージョンは Renovate が管理。「古い依存」としての指摘は不要。
-- **`entrypoint.sh` の `# shellcheck disable=...` コメント**: 検討済みの意図的な抑制。
+- **Lack of tests**: No test framework is set up. Do not uniformly demand unit tests.
+- **`.catch(() => null)` on notification calls**: `axios.post('http://discord-deliver', …).catch(() => null)` is an intentional design that prevents notification failures from stopping the app.
+- **Hardcoded `http://discord-deliver`**: This is a Docker Compose service name, not a secret or a missing config value.
+- **Absolute path `/data/`**: This is an intentional fixed mount point inside the container.
+- **Exclusion of intermediate formats**: The exclusion of `.f140`, `.f248`, `.f299` and simple `.includes` checks are known, intentional specification.
+- **Dependency versions**: Versions in `package.json` and `Dockerfile` (including `YT_DLP_VERSION`) are managed by Renovate. No need to flag them as "outdated dependencies".
+- **`# shellcheck disable=...` comments in `entrypoint.sh`**: These are deliberate, already-considered suppressions.
 
-## 規約リファレンス
+## Convention Reference
 
-- コミット: [Conventional Commits](https://www.conventionalcommits.org/)（`<description>` は日本語）。ブランチ: [Conventional Branch](https://conventional-branch.github.io) 短縮形。
-- Lint/Format: ESLint（`watch-new-movie/eslint.config.mjs`）と Prettier（`watch-new-movie/.prettierrc.yml`）に準拠。CI は `yarn lint` と `yarn compile:test` 相当を実行する。
+- Commits: [Conventional Commits](https://www.conventionalcommits.org/) (`<description>` in English). Branches: [Conventional Branch](https://conventional-branch.github.io) short form.
+- Lint/Format: Follows ESLint (`watch-new-movie/eslint.config.mjs`) and Prettier (`watch-new-movie/.prettierrc.yml`). CI runs the equivalent of `yarn lint` and `yarn compile:test`.

--- a/.github/workflows/check-pr-language.yml
+++ b/.github/workflows/check-pr-language.yml
@@ -1,0 +1,29 @@
+name: Check PR language
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+# Disable all default permissions; grant only what the job needs.
+permissions: {}
+
+jobs:
+  check-pr-language:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: watch-new-movie/.node-version
+
+      - name: Check PR language
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/check-pr-language.mjs

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
-# 任意のレジストリに Docker image を公開orビルドする。
-# プルリクの作成・更新時に動作する。
+# Publishes or builds Docker images to an arbitrary registry.
+# Runs on pull request creation/update.
 
 name: Docker
 
@@ -24,8 +24,8 @@ on:
       - closed
 
 concurrency:
-  # pull_request と pull_request_target が同一グループになると互いをキャンセルしてしまうため
-  # event_name を含めることで両イベントのキャンセルを独立させる
+  # event_name keeps pull_request and pull_request_target cancellation independent,
+  # since sharing the same group would cancel each other out.
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
@@ -33,7 +33,7 @@ jobs:
   post-approval-request:
     name: Post approval request
     runs-on: ubuntu-latest
-    # フォーク PR のときのみ承認リクエストを投稿する（closed は不要）
+    # Post an approval request only for fork PRs (not needed when closed)
     if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.action != 'closed'
     continue-on-error: true
     permissions:
@@ -46,7 +46,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: github-actions[bot]
-          body-includes: Environment 承認待ち
+          body-includes: Waiting for environment approval
 
       - name: Post or update approval request comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
@@ -55,19 +55,19 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           edit-mode: replace
           body: |
-            ## Environment 承認待ち
+            ## Waiting for environment approval
 
-            この PR のビルドを実行するには、Environment `fork-pr-build` の承認が必要です。
+            Approval for the `fork-pr-build` environment is required to run this PR's build.
 
-            [Actions run を確認して承認してください](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }})
+            [Check the Actions run and approve it](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.pull_request.number }})
 
   approval-gate:
     name: Approval gate
     runs-on: ubuntu-latest
     needs: post-approval-request
-    # post-approval-request の結果に関わらず常に実行する
+    # Always run regardless of post-approval-request's result
     if: always()
-    # フォーク PR かつ closed でない場合のみ Environment で手動承認が必要
+    # Manual approval via Environment is required only for fork PRs that are not closed
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && github.event.action != 'closed' && 'fork-pr-build' || '' }}
     permissions: {}
     steps:

--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -1,4 +1,4 @@
-# Node.js でビルド・テストを実行する。バージョンは .node-version に記載されているものを利用する
+# Builds and tests with Node.js, using the version specified in .node-version
 
 name: Node CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,108 +1,107 @@
 # CLAUDE.md
 
-Claude Code がこのリポジトリで作業する際の方針を定義します。
+Defines the guidelines for Claude Code when working in this repository.
 
-## プロジェクト概要
+## Project Overview
 
-YouTube ライブ動画を自動録画・ダウンロードする Docker ベースのアプリケーション。次の 2 サービスで構成されます。
+A Docker-based application that automatically records and downloads YouTube live videos. It consists of the following two services.
 
-- **recorder**（Python/Bash・リポジトリルート）: `yt-dlp` と `ffmpeg` でライブ配信を録画する。ロジックは `entrypoint.sh`。
-- **watch-new-movie**（Node.js/TypeScript・`watch-new-movie/`）: 録画完了した MP4 を検知して Discord へ通知する。
+- **recorder** (Python/Bash, repository root): Records live streams with `yt-dlp` and `ffmpeg`. The logic lives in `entrypoint.sh`.
+- **watch-new-movie** (Node.js/TypeScript, `watch-new-movie/`): Detects finished MP4 recordings and notifies Discord.
 
-通知配信に使う `discord-deliver` は外部 Docker イメージであり、本リポジトリにソースは含まれません。
+`discord-deliver`, used for notification delivery, is an external Docker image; its source is not included in this repository.
 
-## 開発コマンド
+## Development Commands
 
-Node.js アプリのコマンドは `watch-new-movie/` ディレクトリで実行します。
+Run Node.js app commands from the `watch-new-movie/` directory.
 
 ```bash
 cd watch-new-movie
-yarn install         # 依存インストール
-yarn dev             # 開発モード（ts-node-dev で自動リロード）
-yarn build           # ts-node で src/main.ts を直接実行
-yarn start           # コンパイル済み dist/main.js を実行
-yarn compile         # tsc -p . でコンパイル（dist/ 出力）
-yarn compile:test    # tsc --noEmit（型チェックのみ）
-yarn lint            # prettier + eslint + tsc を並列実行
-yarn fix             # prettier --write と eslint --fix
+yarn install         # install dependencies
+yarn dev             # dev mode (auto-reload via ts-node-dev)
+yarn build           # run src/main.ts directly via ts-node
+yarn start           # run the compiled dist/main.js
+yarn compile         # compile with tsc -p . (outputs to dist/)
+yarn compile:test    # tsc --noEmit (type check only)
+yarn lint            # run prettier + eslint + tsc in parallel
+yarn fix             # prettier --write and eslint --fix
 ```
 
-Docker はリポジトリルートで操作します。
+Run Docker commands from the repository root.
 
 ```bash
-docker compose up --build   # ビルドして起動
-docker compose up -d        # バックグラウンド起動
-docker compose logs -f      # ログ確認
-docker compose down         # 停止
+docker compose up --build   # build and start
+docker compose up -d        # start in background
+docker compose logs -f      # view logs
+docker compose down         # stop
 ```
 
-## アーキテクチャと主要ファイル
+## Architecture and Key Files
 
 ```
 .
-├── .github/workflows/          # CI/CD ワークフロー
+├── .github/workflows/          # CI/CD workflows
 ├── watch-new-movie/
-│   └── src/main.ts             # Discord 通知ロジック（唯一のアプリソース）
-├── Dockerfile                  # recorder 用（python:3-slim + yt-dlp/ffmpeg）
-├── entrypoint.sh               # recorder のメインロジック
-├── docker-compose.yml          # 3 サービスのオーケストレーション
-└── renovate.json               # Renovate 設定
+│   └── src/main.ts             # Discord notification logic (the only app source file)
+├── Dockerfile                  # for recorder (python:3-slim + yt-dlp/ffmpeg)
+├── entrypoint.sh               # main logic for recorder
+├── docker-compose.yml          # orchestration of 3 services
+└── renovate.json               # Renovate configuration
 ```
 
-`watch-new-movie/src/main.ts` の動作:
+Behavior of `watch-new-movie/src/main.ts`:
 
-- `/data/` 配下の各ディレクトリから MP4 ファイルを走査する。
-- 中間フォーマットファイル（`.f140` `.f248` `.f299`）は除外する。
-- `/data/notified.json` で通知済みキー（`dirname/filename`）を管理する。
-- 初回実行時（`notified.json` が空）は通知せず、既存ファイルを通知済みとして初期化する。
-- 通知は `http://discord-deliver` へ POST する。成功時は緑（`0x00ff00`）、`main()` 全体のエラー時は赤（`0xff0000`）の Embed。
+- Scans each directory under `/data/` for MP4 files.
+- Excludes intermediate format files (`.f140`, `.f248`, `.f299`).
+- Tracks notified keys (`dirname/filename`) in `/data/notified.json`.
+- On the first run (`notified.json` is empty), does not notify and initializes existing files as already notified.
+- Notifies by POSTing to `http://discord-deliver`. Uses a green (`0x00ff00`) Embed on success, and a red (`0xff0000`) Embed on any error from `main()`.
 
-## コーディング規約
+## Coding Conventions
 
-- **会話言語**: 日本語。**コード内コメント / JSDoc**: 日本語。**エラーメッセージ**: 英語。
-- 日本語と英数字の間には半角スペースを入れる。
-- 関数・インターフェースには日本語 JSDoc を付ける。
-- TypeScript は strict 前提。`skipLibCheck` を有効にして型エラーを回避してはならない。
-- 設定はハードコードせず環境変数で管理する。
-- フォーマットは Prettier（`.prettierrc.yml`）、Lint は ESLint（`eslint.config.mjs`、`@book000/eslint-config` を利用）に従う。
+- **Conversation language**: English. **Code comments / JSDoc**: English. **Error messages**: English.
+- Functions and interfaces must have English JSDoc.
+- TypeScript assumes strict mode. Never enable `skipLibCheck` to bypass type errors.
+- Manage configuration via environment variables, not hardcoded values.
+- Follow Prettier (`.prettierrc.yml`) for formatting and ESLint (`eslint.config.mjs`, using `@book000/eslint-config`) for linting.
 
-## テスト
+## Testing
 
-テストフレームワークは未導入。品質は次で担保する。
+No test framework is set up. Quality is ensured by the following.
 
-- `yarn lint` と `yarn compile:test` がエラーなく通ること。
-- GitHub Actions CI が成功すること。
-- Docker Compose での手動動作確認。
+- `yarn lint` and `yarn compile:test` pass without errors.
+- GitHub Actions CI succeeds.
+- Manual verification via Docker Compose.
 
-## Git / コミット
+## Git / Commits
 
-- コミットメッセージは [Conventional Commits](https://www.conventionalcommits.org/)（`<type>(<scope>): <description>`、`<description>` は日本語）。例: `feat: Discord 通知機能を追加`。
-- ブランチは [Conventional Branch](https://conventional-branch.github.io) 短縮形（`feat`, `fix`, …）。
-- Renovate が作成した PR には追加コミットや更新を行わない。
-- コミット前に機密情報（トークン・パスワード・内部 URL）が含まれないことを確認する。
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <description>`, `<description>` in English). Example: `feat: add Discord notification feature`.
+- Branches use [Conventional Branch](https://conventional-branch.github.io) short form (`feat`, `fix`, …).
+- Do not add commits or updates to PRs created by Renovate.
+- Before committing, confirm no sensitive information (tokens, passwords, internal URLs) is included.
 
-## リポジトリ固有
+## Repository Specifics
 
-- **Docker Hub**: `book000/youtube-live-recorder`（recorder）と `book000/youtube-live-recorder-watch-new-movie`（Node.js）の 2 イメージを公開。
-- **Node.js バージョン**: `watch-new-movie/.node-version` で固定。
-- **yt-dlp バージョン**: ルート `Dockerfile` の `ENV YT_DLP_VERSION` を Renovate が管理。
-- **Deno バージョン**: ルート `Dockerfile` の `ENV DENO_VERSION` を Renovate が管理。yt-dlp が JavaScript ランタイムとして使用する。
+- **Docker Hub**: Publishes two images, `book000/youtube-live-recorder` (recorder) and `book000/youtube-live-recorder-watch-new-movie` (Node.js).
+- **Node.js version**: Pinned in `watch-new-movie/.node-version`.
+- **yt-dlp version**: Managed by Renovate via `ENV YT_DLP_VERSION` in the root `Dockerfile`.
+- **Deno version**: Managed by Renovate via `ENV DENO_VERSION` in the root `Dockerfile`. Used by yt-dlp as a JavaScript runtime.
 - **GitHub Actions**:
-  - `nodejs-ci.yml`: `book000/templates` の再利用可能ワークフローで `watch-new-movie` をビルド。
-  - `docker.yml`: 両 Docker イメージのビルド/公開。
-  - `shell-ci.yml`: ShellCheck。
-  - `hadolint-ci.yml`: Dockerfile Lint。
-  - `add-reviewer.yml`: レビュアー自動割り当て。
-- **環境設定ファイル**（いずれも `.gitignore` 対象）:
-  - `recorder.env`: 録画対象設定（`TARGET`、`CHANNEL`/`PLAYLIST`、`TITLE_FILTER`）。`TARGET` は必須で保存先ディレクトリ名になる。
-  - `discord-deliver.env`: Discord 通知設定。
+  - `nodejs-ci.yml`: Builds `watch-new-movie` via `book000/templates`'s reusable workflow.
+  - `docker.yml`: Builds/publishes both Docker images.
+  - `shell-ci.yml`: ShellCheck.
+  - `hadolint-ci.yml`: Dockerfile lint.
+  - `add-reviewer.yml`: Automatic reviewer assignment.
+- **Environment configuration files** (all `.gitignore`d):
+  - `recorder.env`: Recording target settings (`TARGET`, `CHANNEL`/`PLAYLIST`, `TITLE_FILTER`). `TARGET` is required and becomes the save-destination directory name.
+  - `discord-deliver.env`: Discord notification settings.
 
-## ドキュメント更新
+## Documentation Updates
 
-機能・依存・設定を変更したら、関連ドキュメントを即時更新する。
+When changing a feature, dependency, or configuration, immediately update the related documentation.
 
-- `README.md`: 機能や使い方の変更時。
-- `watch-new-movie/package.json`: 依存・スクリプトの変更時。
-- `docker-compose.yml`: サービス構成の変更時。
-- `watch-new-movie/.node-version`: Node.js バージョンの変更時。
-- このファイル / `.github/copilot-instructions.md`: 作業方針やルールの変更時。
+- `README.md`: When features or usage change.
+- `watch-new-movie/package.json`: When dependencies or scripts change.
+- `docker-compose.yml`: When service composition changes.
+- `watch-new-movie/.node-version`: When the Node.js version changes.
+- This file / `.github/copilot-instructions.md`: When work policy or rules change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ docker compose down         # stop
 ```
 .
 ├── .github/workflows/          # CI/CD workflows
+├── scripts/                    # CI helper scripts (dependency-free)
 ├── watch-new-movie/
 │   └── src/main.ts             # Discord notification logic (the only app source file)
 ├── Dockerfile                  # for recorder (python:3-slim + yt-dlp/ffmpeg)
@@ -53,13 +54,15 @@ Behavior of `watch-new-movie/src/main.ts`:
 
 - Scans each directory under `/data/` for MP4 files.
 - Excludes intermediate format files (`.f140`, `.f248`, `.f299`).
-- Tracks notified keys (`dirname/filename`) in `/data/notified.json`.
-- On the first run (`notified.json` is empty), does not notify and initializes existing files as already notified.
+- Tracks notified keys (`dirname/filename`) in `/data/notified.json`. Do not remove this idempotency check — it is what prevents duplicate Discord notifications on every scan.
+- On the first run (`notified.json` is empty), does not notify and initializes existing files as already notified. This is intentional bootstrap behavior, not a bug to fix.
 - Notifies by POSTing to `http://discord-deliver`. Uses a green (`0x00ff00`) Embed on success, and a red (`0xff0000`) Embed on any error from `main()`.
 
 ## Coding Conventions
 
-- **Conversation language**: English. **Code comments / JSDoc**: English. **Error messages**: English.
+- Project language: English is the primary language for all project artifacts (code, comments, commit messages, PR titles/bodies, and documentation). The only exception is direct conversation with Claude Code itself, which follows the user's personal/global instructions.
+- Code comments / JSDoc: English. Error messages: English.
+- Shell/script output (recorder logs, `entrypoint.sh` messages) is English, without emoji.
 - Functions and interfaces must have English JSDoc.
 - TypeScript assumes strict mode. Never enable `skipLibCheck` to bypass type errors.
 - Manage configuration via environment variables, not hardcoded values.
@@ -79,6 +82,12 @@ No test framework is set up. Quality is ensured by the following.
 - Branches use [Conventional Branch](https://conventional-branch.github.io) short form (`feat`, `fix`, …).
 - Do not add commits or updates to PRs created by Renovate.
 - Before committing, confirm no sensitive information (tokens, passwords, internal URLs) is included.
+- PR titles and bodies must be in English (enforced by `check-pr-language.yml`).
+
+## Security
+
+- Never commit real values for `recorder.env` or `discord-deliver.env` (both `.gitignore`d).
+- Never log credential or token values, even in debug output.
 
 ## Repository Specifics
 
@@ -92,6 +101,7 @@ No test framework is set up. Quality is ensured by the following.
   - `shell-ci.yml`: ShellCheck.
   - `hadolint-ci.yml`: Dockerfile lint.
   - `add-reviewer.yml`: Automatic reviewer assignment.
+  - `check-pr-language.yml`: Fails the PR if its title or body is mostly Japanese.
 - **Environment configuration files** (all `.gitignore`d):
   - `recorder.env`: Recording target settings (`TARGET`, `CHANNEL`/`PLAYLIST`, `TITLE_FILTER`). `TARGET` is required and becomes the save-destination directory name.
   - `discord-deliver.env`: Discord notification settings.
@@ -105,3 +115,4 @@ When changing a feature, dependency, or configuration, immediately update the re
 - `docker-compose.yml`: When service composition changes.
 - `watch-new-movie/.node-version`: When the Node.js version changes.
 - This file / `.github/copilot-instructions.md`: When work policy or rules change.
+- When changing the Discord notification embed format/fields or the `notified.json` schema in `watch-new-movie/src/main.ts`, update both `README.md`'s usage section and this file's `watch-new-movie/src/main.ts` behavior bullets in the same change.

--- a/scripts/check-pr-language.mjs
+++ b/scripts/check-pr-language.mjs
@@ -52,7 +52,7 @@ function calculateJapaneseRatio(text) {
  * that English identifiers inside code snippets do not dilute the ratio.
  * The body is skipped if it is empty (or only whitespace).
  *
- * @param title - PR title
+ * @param title - PR title (may be `null`/`undefined`/empty)
  * @param body - PR body (may be `null`/`undefined`/empty)
  * @returns An array of human-readable failure messages. Empty if both the
  *   title and body pass the check.

--- a/scripts/check-pr-language.mjs
+++ b/scripts/check-pr-language.mjs
@@ -1,0 +1,97 @@
+// Checks whether a PR title/body is mostly written in Japanese.
+// Dependency-free Node.js ESM script intended to be run from CI via
+// `pull_request` (see .github/workflows/check-pr-language.yml).
+
+// Threshold (inclusive) above which the text is considered "mostly Japanese".
+const JAPANESE_RATIO_THRESHOLD = 0.8
+
+// Hiragana, katakana, and CJK Unified Ideographs (incl. extension A).
+const JAPANESE_PATTERN = /[぀-ゟ゠-ヿ㐀-䶿一-鿿]/gu
+// Latin letters and digits.
+const LATIN_PATTERN = /[A-Za-z0-9]/gu
+
+/**
+ * Strips Markdown fenced code blocks (``` ... ```) and inline code (` ... `)
+ * from the given text so that code snippets do not dilute the language ratio.
+ *
+ * @param text - Markdown text to strip
+ * @returns Text with code blocks and inline code removed
+ */
+function stripMarkdownCode(text) {
+  // Remove fenced code blocks (3 or more backticks, per CommonMark spec)
+  let stripped = text.replaceAll(/`{3,}[\s\S]*?`{3,}/g, '')
+  // Remove inline code (1 or more backticks as delimiter, no newline inside)
+  stripped = stripped.replaceAll(/`+[^`\n]*`+/g, '')
+  return stripped
+}
+
+/**
+ * Calculates the ratio of Japanese characters to the total number of
+ * Japanese and Latin alphanumeric characters in the given text.
+ *
+ * @param text - Text to inspect
+ * @returns A ratio between 0 and 1. Returns 0 if the text contains neither
+ *   Japanese nor Latin alphanumeric characters.
+ */
+function calculateJapaneseRatio(text) {
+  const japaneseCount = (text.match(JAPANESE_PATTERN) ?? []).length
+  const latinCount = (text.match(LATIN_PATTERN) ?? []).length
+  const total = japaneseCount + latinCount
+
+  if (total === 0) {
+    return 0
+  }
+
+  return japaneseCount / total
+}
+
+/**
+ * Checks the PR title and body against {@link JAPANESE_RATIO_THRESHOLD}.
+ *
+ * Code blocks and inline code are stripped from the body before checking so
+ * that English identifiers inside code snippets do not dilute the ratio.
+ * The body is skipped if it is empty (or only whitespace).
+ *
+ * @param title - PR title
+ * @param body - PR body (may be `null`/`undefined`/empty)
+ * @returns An array of human-readable failure messages. Empty if both the
+ *   title and body pass the check.
+ */
+export function checkPullRequestLanguage(title, body) {
+  const failures = []
+
+  const titleRatio = calculateJapaneseRatio(title ?? '')
+  if (titleRatio >= JAPANESE_RATIO_THRESHOLD) {
+    failures.push(
+      `PR title appears to be mostly Japanese (Japanese ratio: ${titleRatio.toFixed(2)}). Please write the PR title in English.`
+    )
+  }
+
+  const trimmedBody = (body ?? '').trim()
+  if (trimmedBody.length > 0) {
+    const strippedBody = stripMarkdownCode(trimmedBody)
+    const bodyRatio = calculateJapaneseRatio(strippedBody)
+    if (bodyRatio >= JAPANESE_RATIO_THRESHOLD) {
+      failures.push(
+        `PR body appears to be mostly Japanese (Japanese ratio: ${bodyRatio.toFixed(2)}). Please write the PR body in English.`
+      )
+    }
+  }
+
+  return failures
+}
+
+// Only run as a CLI check when executed directly (not when imported by the test file).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const title = process.env.PR_TITLE ?? ''
+  const body = process.env.PR_BODY ?? ''
+
+  const failures = checkPullRequestLanguage(title, body)
+  for (const failure of failures) {
+    console.error(failure)
+  }
+
+  if (failures.length > 0) {
+    process.exitCode = 1
+  }
+}

--- a/scripts/check-pr-language.test.mjs
+++ b/scripts/check-pr-language.test.mjs
@@ -51,3 +51,18 @@ test('an empty body is skipped, not treated as a failure', () => {
   const failures = checkPullRequestLanguage('fix: correct pagination bug', '')
   assert.deepEqual(failures, [])
 })
+
+test('null/undefined title and body are treated as empty, not a failure', () => {
+  assert.deepEqual(checkPullRequestLanguage(null, null), [])
+  assert.deepEqual(checkPullRequestLanguage(undefined, undefined), [])
+})
+
+test('the Japanese ratio threshold is inclusive at exactly 0.8', () => {
+  // 8 Japanese characters + 2 Latin characters = ratio of exactly 0.8.
+  const atThreshold = checkPullRequestLanguage('あいうえおかきくAB', '')
+  assert.equal(atThreshold.length, 1)
+
+  // 7 Japanese characters + 3 Latin characters = ratio just below 0.8.
+  const belowThreshold = checkPullRequestLanguage('あいうえおかきABC', '')
+  assert.deepEqual(belowThreshold, [])
+})

--- a/scripts/check-pr-language.test.mjs
+++ b/scripts/check-pr-language.test.mjs
@@ -1,0 +1,53 @@
+// Minimal self-check for check-pr-language.mjs's language-ratio logic.
+// Run with: node --test scripts/check-pr-language.test.mjs
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { checkPullRequestLanguage } from './check-pr-language.mjs'
+
+test('passes for an English title and body', () => {
+  const failures = checkPullRequestLanguage(
+    'fix: correct off-by-one error in pagination',
+    'This change fixes an off-by-one error introduced in the previous release.'
+  )
+  assert.deepEqual(failures, [])
+})
+
+test('fails for a mostly-Japanese title', () => {
+  const failures = checkPullRequestLanguage(
+    'fix: ページネーションのオフバイワンエラーを修正する',
+    'This change fixes an off-by-one error.'
+  )
+  assert.equal(failures.length, 1)
+  assert.match(failures[0], /title/i)
+})
+
+test('fails for a mostly-Japanese body', () => {
+  const failures = checkPullRequestLanguage(
+    'fix: correct pagination bug',
+    '前回のリリースで発生したオフバイワンエラーを修正しました。'
+  )
+  assert.equal(failures.length, 1)
+  assert.match(failures[0], /body/i)
+})
+
+test('code blocks and inline code do not count toward the Japanese ratio', () => {
+  const failures = checkPullRequestLanguage(
+    'fix: correct pagination bug',
+    [
+      'Fixes an off-by-one error.',
+      '',
+      '```bash',
+      '日本語のコメントを含むコードブロック',
+      '```',
+      '',
+      'See `変数名の例` for the affected variable.',
+    ].join('\n')
+  )
+  assert.deepEqual(failures, [])
+})
+
+test('an empty body is skipped, not treated as a failure', () => {
+  const failures = checkPullRequestLanguage('fix: correct pagination bug', '')
+  assert.deepEqual(failures, [])
+})


### PR DESCRIPTION
## Summary

Makes English the project's primary language, per Issue #1410. All remaining Japanese text in project conventions and CI-facing documentation was translated to English, and a CI check now enforces English PR titles/bodies going forward.

## Changes

- `CLAUDE.md`: Fully translated to English. Adds an explicit "Project language" convention (English for code, comments, commit messages, PR titles/bodies, and documentation; direct conversation with Claude Code is exempt), a Security section, and documents the new `check-pr-language.yml` check.
- `.github/copilot-instructions.md`: Fully translated to English. Adds matching review guidance (shell/script output convention, idempotency invariants, a note against suggesting new tools/dependencies not already in the repo) and references the new language check.
- `.github/workflows/docker.yml`: Comments and the fork-PR approval-wait bot comment translated to English (the `find-comment` `body-includes` match was updated to stay consistent with the new heading).
- `.github/workflows/nodejs-ci.yml`: Comment translated to English.
- `.github/workflows/check-pr-language.yml` (new) + `scripts/check-pr-language.mjs` (new) + `scripts/check-pr-language.test.mjs` (new): CI check that fails a PR if its title or body is mostly Japanese. Ported from `book000/pixivts`'s existing check, adapted to use `pull_request` (no privileged token needed here) and this repo's plain (non-emoji) step-name convention.

No application logic or runtime CI behavior changed — this is a documentation/comment/CI-policy change only.

Closes #1410

Spec: https://github.com/book000/youtube-live-recorder/issues/1410#issuecomment-5310904252
Plan: https://github.com/book000/youtube-live-recorder/issues/1410#issuecomment-5310966049
